### PR TITLE
Add rule warning against scoped rules that are no injectable

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -198,6 +198,28 @@ class MyThing @Inject constructor()
 class MyOtherThing @Inject constructor()
 ```
 
+### Classes annotated with scopes require their constructors to be annotated with `@Inject` to be added to the Dagger graph
+
+Dagger supports the concept of scoping classes to the lifecycle of `Components` by annotating them with the same scope
+annotation **and adding them to the DI graph**.
+For example, if there is an `AppComponent` annotated with the `@Singleton` scope
+and another class in the project is annotated with `@Singleton` the same instance of that class will be
+retained as long as `AppComponent` is.
+Adding the same scope annotation is only part of the process, we must all ensure the class is added to the Dagger graph
+by annotating one of its constructors with the `@Inject` annotation.
+
+```kotlin
+@Singleton
+@Component
+interface AppComponent
+
+// Is not part of the DI graph and won't be scoped as a singleton
+@Singleton MyClass()
+
+// is part of the DI graph and will be scoped as a singleton
+@Singleton MyOtherClass @Inject constructor()
+```
+
 ## Anvil Rules
 
 ### Prefer using `@ContributesBinding` over `@Binds`

--- a/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/DaggerRulesIssueRegistry.kt
+++ b/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/DaggerRulesIssueRegistry.kt
@@ -14,6 +14,7 @@ import dev.whosnickdoglio.dagger.detectors.ConstructorInjectionOverFieldInjectio
 import dev.whosnickdoglio.dagger.detectors.CorrectBindsUsageDetector
 import dev.whosnickdoglio.dagger.detectors.MissingModuleAnnotationDetector
 import dev.whosnickdoglio.dagger.detectors.MultipleScopesDetector
+import dev.whosnickdoglio.dagger.detectors.ScopedWithoutInjectAnnotationDetector
 import dev.whosnickdoglio.dagger.detectors.StaticProvidesDetector
 
 @AutoService(IssueRegistry::class)
@@ -28,6 +29,7 @@ class DaggerRulesIssueRegistry : IssueRegistry() {
             MissingModuleAnnotationDetector.ISSUE,
             MultipleScopesDetector.ISSUE,
             StaticProvidesDetector.ISSUE,
+            ScopedWithoutInjectAnnotationDetector.ISSUE,
         )
 
     override val api: Int = CURRENT_API

--- a/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ScopedWithoutInjectAnnotationDetector.kt
+++ b/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ScopedWithoutInjectAnnotationDetector.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Nicholas Doglio
+ * SPDX-License-Identifier: MIT
+ */
+package dev.whosnickdoglio.dagger.detectors
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import dev.whosnickdoglio.lint.shared.INJECT
+import dev.whosnickdoglio.lint.shared.SCOPE
+import org.jetbrains.uast.UAnnotated
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.resolveToUElement
+
+/**
+ * A Lint rule that warns if a class is annotated with any scope annotation but does not have a
+ * `@Inject` annotation on any constructor that it will not be added to the Dagger graph.
+ */
+internal class ScopedWithoutInjectAnnotationDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitClass(node: UClass) {
+                if (!context.evaluator.isAbstract(node)) {
+                    val sourceScopeAnnotations =
+                        node.uAnnotations
+                            .map { annotation -> annotation.resolveToUElement() }
+                            .filterIsInstance<UAnnotated>()
+                            .filter { annotated ->
+                                annotated.uAnnotations.any { annotation ->
+                                    annotation.qualifiedName == SCOPE
+                                }
+                            }
+                            .filterIsInstance<UClass>()
+
+                    val scopeAnnotations =
+                        node.uAnnotations.filter { annotation ->
+                            sourceScopeAnnotations.any { scope ->
+                                scope.qualifiedName == annotation.qualifiedName
+                            }
+                        }
+
+                    val isInjected =
+                        node.constructors.any { constructor -> constructor.hasAnnotation(INJECT) }
+
+                    if (scopeAnnotations.isNotEmpty() && !isInjected) {
+                        scopeAnnotations.forEach { annotation ->
+                            context.report(
+                                issue = ISSUE,
+                                location = context.getLocation(annotation),
+                                message = ISSUE.getExplanation(TextFormat.TEXT),
+                                quickfixData =
+                                    fix()
+                                        .name("Remove unnecessary scope annotation")
+                                        .replace()
+                                        .text(annotation.asRenderString())
+                                        .with("")
+                                        .build(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+    companion object {
+        private val implementation =
+            Implementation(ScopedWithoutInjectAnnotationDetector::class.java, Scope.JAVA_FILE_SCOPE)
+
+        internal val ISSUE =
+            Issue.create(
+                id = "ScopedWithoutInjection",
+                briefDescription = "Class is scoped without using the `@Inject` annotation",
+                explanation =
+                    "Without the `@Inject` annotation this class is not added to the " +
+                        "DI graph which means the scope annotation doesn't do anything.",
+                category = Category.CORRECTNESS,
+                priority = 5,
+                severity = Severity.ERROR,
+                implementation = implementation
+            )
+    }
+}

--- a/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ScopedWithoutInjectAnnotationDetectorTest.kt
+++ b/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ScopedWithoutInjectAnnotationDetectorTest.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2023 Nicholas Doglio
+ * SPDX-License-Identifier: MIT
+ */
+package dev.whosnickdoglio.dagger.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import dev.whosnickdoglio.stubs.daggerAnnotations
+import dev.whosnickdoglio.stubs.javaxAnnotations
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class ScopedWithoutInjectAnnotationDetectorTest {
+
+    @Test
+    fun `kotlin scoped class without inject annotation triggers error message`(
+        @TestParameter scopeFile: ScopeTestFile
+    ) {
+        TestLintTask.lint()
+            .files(javaxAnnotations, scopeFile.file, TestFiles.kotlin("@MyScope class MyClass"))
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                    src/MyClass.kt:1: Error: Without the @Inject annotation this class is not added to the DI graph which means the scope annotation doesn't do anything. [ScopedWithoutInjection]
+                    @MyScope class MyClass
+                    ~~~~~~~~
+                    1 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectErrorCount(1)
+            .expectFixDiffs(
+                """
+                    Fix for src/MyClass.kt line 1: Remove unnecessary scope annotation:
+                    @@ -1 +1
+                    - @MyScope class MyClass
+                    +  class MyClass
+                """
+                    .trimIndent()
+            )
+    }
+
+    @Test
+    fun `java scoped class without inject annotation triggers error message`(
+        @TestParameter scopeFile: ScopeTestFile
+    ) {
+        TestLintTask.lint()
+            .files(javaxAnnotations, scopeFile.file, TestFiles.java("@MyScope class MyClass {}"))
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                    src/MyClass.java:1: Error: Without the @Inject annotation this class is not added to the DI graph which means the scope annotation doesn't do anything. [ScopedWithoutInjection]
+                    @MyScope class MyClass {}
+                    ~~~~~~~~
+                    1 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                    Fix for src/MyClass.java line 1: Remove unnecessary scope annotation:
+                    @@ -1 +1
+                    - @MyScope class MyClass {}
+                    +  class MyClass {}
+                """
+                    .trimIndent()
+            )
+    }
+
+    @Test
+    fun `kotlin scoped class with inject annotation does not trigger error message`(
+        @TestParameter scopeFile: ScopeTestFile
+    ) {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                scopeFile.file,
+                TestFiles.kotlin(
+                    """
+                import javax.inject.Inject
+
+                @MyScope class MyClass @Inject constructor()
+                    """
+                        .trimIndent()
+                )
+            )
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+
+    @Test
+    fun `java scoped class with inject annotation does not trigger error message`(
+        @TestParameter scopeFile: ScopeTestFile
+    ) {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                scopeFile.file,
+                TestFiles.java(
+                    """
+                    import javax.inject.Inject;
+
+                    @MyScope class MyClass {
+
+                        @Inject public MyClass() {}
+                    }
+                """
+                        .trimIndent()
+                )
+            )
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `kotlin class without scope but with inject annotation does not trigger error message`() {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                TestFiles.kotlin(
+                    """
+                    import javax.inject.Inject
+
+                    class MyClass @Inject constructor()
+                """
+                        .trimIndent()
+                )
+            )
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `java class without scope with inject annotation does not trigger error message`() {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                TestFiles.java(
+                    """
+                    import javax.inject.Inject;
+
+                    class MyClass {
+
+                        @Inject public MyClass() {}
+                    }
+                """
+                        .trimIndent()
+                )
+            )
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `kotlin class with no scope or inject annotations shows no error message`() {
+        TestLintTask.lint()
+            .files(TestFiles.kotlin("class MyClass"))
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+
+    @Test
+    fun `java class with no scope or inject annotations shows no error message`() {
+        TestLintTask.lint()
+            .files(TestFiles.java("class MyClass {}"))
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `kotlin @Component definition with a scope does not show an error message`(
+        @TestParameter scopeFile: ScopeTestFile
+    ) {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                scopeFile.file,
+                daggerAnnotations,
+                TestFiles.kotlin(
+                    """
+                import dagger.Component
+
+                @MyScope @Component interface MyComponent
+            """
+                        .trimIndent()
+                )
+            )
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+
+    @Test
+    fun `java @Component definition with a scope does not show an error message`(
+        @TestParameter scopeFile: ScopeTestFile
+    ) {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                scopeFile.file,
+                daggerAnnotations,
+                TestFiles.java(
+                    """
+                import dagger.Component;
+
+                @MyScope @Component interface MyComponent {}
+            """
+                        .trimIndent()
+                )
+            )
+            .issues(ScopedWithoutInjectAnnotationDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+}
+
+@Suppress("unused")
+enum class ScopeTestFile(val file: TestFile) {
+    KOTLIN(
+        TestFiles.kotlin(
+            """
+        import javax.inject.Scope
+        @Scope annotation class MyScope
+        """
+                .trimIndent()
+        )
+    ),
+    JAVA(
+        TestFiles.java(
+            """
+        import javax.inject.Scope;
+
+        @Scope
+        public @interface MyScope {}
+        """
+                .trimIndent()
+        )
+    ),
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a rule to warn against objects that is annotated with a scope annotation **but is not** part of the DI graph so the scope doesn't actually do anything. 

```kotlin
@Singleton // This annotation does nothing! But when you read the code you may think it does
Class Foo {}
```

The meat of this is in `ScopedWithoutInjectAnnotationDetector`, the rest of the changes are docs or unit tests. 


## Related Issue

Closes #151 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the style guidelines of this project (`./gradlew lint spotlessCheck`)
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have mentioned changes in [CHANGELOG.md](../CHANGELOG.md).
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
