### PR TITLE
Make MissingInstallInDetector configurable

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -178,15 +178,18 @@ here: [Keeping the Daggers Sharp](https://developer.squareup.com/blog/keeping-th
 
 Dagger supports the concept of scoping classes to the lifecycle of `Components` by annotating them with the same scope
 annotation. This means when you access a dependency that shares the same scope annotation as a `Component` you will get
-the same instance each time. Scopes, however, are not repeatable, and you are unable to connect a class to multiple scopes;
+the same instance each time. Scopes, however, are not repeatable, and you are unable to connect a class to multiple
+scopes;
 Dagger will fail at compile time when attempting to do this.
 
 `error: A single binding may not declare more than one @Scope`
 
 ```kotlin
-@Scope annotation class AppScope
+@Scope
+annotation class AppScope
 
-@Scope annotation class FeatureScope
+@Scope
+annotation class FeatureScope
 
 // Unsafe will error at compile time
 @FeatureScope
@@ -478,3 +481,19 @@ object MySafeModule {
     fun provideMyFactory(): MyFactory = MyFactory.create()
 }
 ```
+
+This rule is also configurable if you have custom Hilt components already defined!
+In your `lint.xml` file you can add a
+list of fully qualified class names for any custom Hilt components to be included in the quick fix suggestions.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="MissingInstallInAnnotation">
+        <option name="customHiltComponents" value="dev.whosnickdoglio.testapp.hilt.MyCustomComponent"/>
+    </issue>
+</lint>
+```
+
+You can read more about this
+in [the Lint API guide](https://googlesamples.github.io/android-custom-lint-rules/api-guide.html#options/usage).

--- a/test-app/lint.xml
+++ b/test-app/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="MissingInstallInAnnotation">
+        <option name="customHiltComponents" value="dev.whosnickdoglio.testapp.hilt.MyCustomComponent"/>
+    </issue>
+</lint>

--- a/test-app/src/main/java/dev/whosnickdoglio/testapp/hilt/MyCustomComponent.kt
+++ b/test-app/src/main/java/dev/whosnickdoglio/testapp/hilt/MyCustomComponent.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Nicholas Doglio
+ * SPDX-License-Identifier: MIT
+ */
+
+package dev.whosnickdoglio.testapp.hilt
+
+import android.content.Context
+import dagger.BindsInstance
+import dagger.hilt.DefineComponent
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Scope
+
+@MyCustomScope
+@DefineComponent(parent = SingletonComponent::class)
+interface MyCustomComponent {
+
+    @DefineComponent.Builder
+    interface Builder {
+        fun context(@BindsInstance context: Context): Builder
+
+        fun build(): MyCustomComponent
+    }
+}
+
+@Scope @Retention annotation class MyCustomScope


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the  `MissingInstallInDetector` to take a `StringOption` that lets consumers define a list of custom Hilt Components to be included as part of Lints quick fix suggestions for missing `@InstallIn` annotations. 

<img width="764" alt="Screenshot 2024-01-05 at 12 00 31 PM" src="https://github.com/WhosNickDoglio/dagger-rules/assets/3968678/fa5b712b-587f-4442-a728-f7b9ab6170ce">


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the style guidelines of this project (`./gradlew lint spotlessCheck`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have mentioned changes in [CHANGELOG.md](../CHANGELOG.md).
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
