### PR TITLE
Add rule to warn against using scopes with assisted injection

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -295,6 +295,14 @@ annotated with `@Inject` will be supplied.
 More information here: [
 `@Component` Dagger documentation](https://dagger.dev/api/latest/dagger/Component.html)
 
+## Classes that use `@AssistedInject` cannot be scoped
+
+The [`@AssistedInject`](https://dagger.dev/api/latest/dagger/assisted/AssistedInject.html)
+annotation is used to denote a class needs some assistance to be constructed, Dagger will supply
+most of the dependencies and anything annotated with `@Assisted` will be provided at runtime. Due to
+how these classes classes not being fully constructed by Dagger we can't scope them, trying to do so
+will result in a compile time error.
+
 ## Hilt Rules
 
 ### The `@EntryPoint` annotation can only be applied to interfaces

--- a/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/DaggerRulesIssueRegistry.kt
+++ b/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/DaggerRulesIssueRegistry.kt
@@ -12,6 +12,7 @@ import dev.whosnickdoglio.dagger.detectors.ConstructorInjectionOverFieldInjectio
 import dev.whosnickdoglio.dagger.detectors.CorrectBindsUsageDetector
 import dev.whosnickdoglio.dagger.detectors.MissingModuleAnnotationDetector
 import dev.whosnickdoglio.dagger.detectors.MultipleScopesDetector
+import dev.whosnickdoglio.dagger.detectors.ScopedAssistedInjectedDetector
 import dev.whosnickdoglio.dagger.detectors.ScopedWithoutInjectAnnotationDetector
 import dev.whosnickdoglio.dagger.detectors.StaticProvidesDetector
 import dev.whosnickdoglio.dagger.detectors.ValidComponentMethodDetector
@@ -27,6 +28,7 @@ public class DaggerRulesIssueRegistry : IssueRegistry() {
             MissingModuleAnnotationDetector.ISSUE,
             MultipleScopesDetector.ISSUE,
             StaticProvidesDetector.ISSUE,
+            ScopedAssistedInjectedDetector.ISSUE,
             ScopedWithoutInjectAnnotationDetector.ISSUE,
             ValidComponentMethodDetector.ISSUE,
         )

--- a/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ScopedAssistedInjectedDetector.kt
+++ b/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ScopedAssistedInjectedDetector.kt
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 Nicholas Doglio
+// SPDX-License-Identifier: MIT
+package dev.whosnickdoglio.dagger.detectors
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import dev.whosnickdoglio.lint.annotations.dagger.ASSISTED_INJECT
+import dev.whosnickdoglio.lint.annotations.dagger.SCOPE
+import org.jetbrains.uast.UAnnotated
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.resolveToUElement
+
+/**
+ * A Lint rule that warns if a class is annotated with any scope annotation but does not have a
+ * `@Inject` annotation on any constructor that it will not be added to the Dagger graph.
+ */
+internal class ScopedAssistedInjectedDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitClass(node: UClass) {
+                val sourceScopeAnnotations =
+                    node.uAnnotations
+                        .map { annotation -> annotation.resolveToUElement() }
+                        .filterIsInstance<UAnnotated>()
+                        .filter { annotated ->
+                            annotated.uAnnotations.any { annotation ->
+                                annotation.qualifiedName == SCOPE
+                            }
+                        }
+                        .filterIsInstance<UClass>()
+
+                val scopeAnnotationsOnCurrentClass =
+                    node.uAnnotations.filter { annotation ->
+                        sourceScopeAnnotations.any { scope ->
+                            scope.qualifiedName == annotation.qualifiedName
+                        }
+                    }
+
+                val usesAssistedInjection =
+                    node.javaPsi.constructors.any { constructor ->
+                        constructor.hasAnnotation(ASSISTED_INJECT)
+                    }
+
+                if (scopeAnnotationsOnCurrentClass.isNotEmpty() && usesAssistedInjection) {
+                    scopeAnnotationsOnCurrentClass.forEach { scopeAnnotation ->
+                        context.report(
+                            issue = ISSUE,
+                            location = context.getLocation(scopeAnnotation),
+                            message = ISSUE.getExplanation(TextFormat.RAW),
+                            quickfixData =
+                                fix()
+                                    .name("Remove scope annotation")
+                                    .replace()
+                                    .pattern(
+                                        "(?i)(.*${scopeAnnotation.qualifiedName?.substringAfterLast(".")})"
+                                    )
+                                    .reformat(true)
+                                    .with("")
+                                    .build(),
+                        )
+                    }
+                }
+            }
+        }
+
+    companion object {
+        private val implementation =
+            Implementation(ScopedAssistedInjectedDetector::class.java, Scope.JAVA_FILE_SCOPE)
+
+        internal val ISSUE =
+            Issue.create(
+                id = "ScopedAssistedInject",
+                briefDescription = "Classes using assisted inject cannot be scoped",
+                explanation = "Classes using assisted inject cannot be scoped",
+                category = Category.CORRECTNESS,
+                priority = 5,
+                severity = Severity.ERROR,
+                implementation = implementation,
+            )
+    }
+}

--- a/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ScopedAssistedInjectedDetectorTest.kt
+++ b/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ScopedAssistedInjectedDetectorTest.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2024 Nicholas Doglio
+ * SPDX-License-Identifier: MIT
+ */
+package dev.whosnickdoglio.dagger.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import dev.whosnickdoglio.stubs.daggerAnnotations
+import dev.whosnickdoglio.stubs.daggerAssistedAnnotations
+import dev.whosnickdoglio.stubs.javaxAnnotations
+import org.junit.Test
+
+class ScopedAssistedInjectedDetectorTest {
+
+    private val myScope =
+        TestFiles.kotlin(
+            """
+            import javax.inject.Scope
+            @Scope annotation class MyScope
+            """
+                .trimIndent()
+        )
+
+    @Test
+    fun `scoped kotlin class using @AssistedInject triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                daggerAssistedAnnotations,
+                javaxAnnotations,
+                myScope,
+                TestFiles.kotlin(
+                        """
+                import dagger.assisted.AssistedInject
+                import dagger.assisted.Assisted
+
+                @MyScope class MyAssistedClass @AssistedInject constructor(
+                        private val myInt: Int,
+                        @Assisted private val something: String
+                )
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ScopedAssistedInjectedDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/MyAssistedClass.kt:4: Error: Classes using assisted inject cannot be scoped [ScopedAssistedInject]
+                @MyScope class MyAssistedClass @AssistedInject constructor(
+                ~~~~~~~~
+                1 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectErrorCount(1)
+            .expectFixDiffs(
+                """
+                Fix for src/MyAssistedClass.kt line 4: Remove scope annotation:
+                @@ -4 +4
+                - @MyScope class MyAssistedClass @AssistedInject constructor(
+                +  class MyAssistedClass @AssistedInject constructor(
+                """
+                    .trimIndent()
+            )
+    }
+
+    @Test
+    fun `scoped java class using @AssistedInject triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                daggerAssistedAnnotations,
+                javaxAnnotations,
+                myScope,
+                TestFiles.java(
+                        """
+                import dagger.assisted.AssistedInject;
+                import dagger.assisted.Assisted;
+
+                @MyScope class MyAssistedClass {
+
+                        @AssistedInject MyAssistedClass(
+                            String something,
+                            @Assisted Boolean somethingElse
+                        ) {}
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ScopedAssistedInjectedDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/MyAssistedClass.java:4: Error: Classes using assisted inject cannot be scoped [ScopedAssistedInject]
+                @MyScope class MyAssistedClass {
+                ~~~~~~~~
+                1 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectErrorCount(1)
+            .expectFixDiffs(
+                """
+                Fix for src/MyAssistedClass.java line 4: Remove scope annotation:
+                @@ -4 +4
+                - @MyScope class MyAssistedClass {
+                +  class MyAssistedClass {
+                """
+                    .trimIndent()
+            )
+    }
+
+    @Test
+    fun `kotlin class without scope using @AssistedInject does not triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                daggerAssistedAnnotations,
+                javaxAnnotations,
+                TestFiles.kotlin(
+                        """
+                import dagger.assisted.AssistedInject
+                import dagger.assisted.Assisted
+
+                class MyAssistedClass @AssistedInject constructor(
+                        private val myInt: Int,
+                        @Assisted private val something: String
+                )
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ScopedAssistedInjectedDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+
+    @Test
+    fun `java class without scope using @AssistedInject does not triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                daggerAssistedAnnotations,
+                javaxAnnotations,
+                TestFiles.java(
+                        """
+                import dagger.assisted.AssistedInject;
+                import dagger.assisted.Assisted;
+
+                class MyAssistedClass {
+
+                        @AssistedInject MyAssistedClass(
+                            String something,
+                            @Assisted Boolean somethingElse
+                        ) {}
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ScopedAssistedInjectedDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+
+    @Test
+    fun `scoped kotlin class not using @AssistedInject does not triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                daggerAssistedAnnotations,
+                javaxAnnotations,
+                myScope,
+                TestFiles.kotlin(
+                        """
+                import javax.inject.Inject
+
+                @MyScope class MyAssistedClass @Inject constructor(something: String)
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ScopedAssistedInjectedDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+
+    @Test
+    fun `scoped java class not using @AssistedInject does not triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                daggerAssistedAnnotations,
+                javaxAnnotations,
+                myScope,
+                TestFiles.java(
+                        """
+                import javax.inject.Inject;
+
+                @MyScope class MyAssistedClass {
+
+                        @Inject MyAssistedClass(
+                            String something,
+                            Boolean somethingElse
+                        ) {}
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ScopedAssistedInjectedDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectErrorCount(0)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the style guidelines of this project (`./gradlew lint spotlessCheck`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have mentioned changes in [CHANGELOG.md](../CHANGELOG.md).
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.

* `main` <!-- branch-stack -->
  - **Add rule to warn against using scopes with assisted injection** :point\_left:
