### PR TITLE
Add a rule to warn against invalid methods on component interfaces

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -34,7 +34,7 @@ or `Fragments`)
 if the creation of the class you're trying to add to the Dagger graph isn't managed by something else like the Android
 OS you should be using constructor injection.
 
-```kotlin 
+```kotlin
 
 class MyClass {
     // BAD! don't do this!
@@ -223,6 +223,53 @@ interface AppComponent
 @Singleton MyOtherClass @Inject constructor()
 ```
 
+### Valid `@Component` methods
+
+`@Components` and `@Subcomponents` only support two types of methods, provision methods and members-injection methods.
+Trying to add any other kind of method to your component will lead to a crash at compile time.
+
+#### Provision methods
+
+Provision methods cover exposing specific dependencies from your graph via the `@Component`
+and are defined as "Provision methods have no parameters and return an injected or provided type."
+
+```kotlin
+
+// All valid provision methods
+@Component
+interface AppComponent {
+
+    fun myThing(): MyThing
+
+    fun myMultipleOtherThings(): Set<MyOtherThing>
+
+    @Qualified
+    fun MyQualifiedThing(): MyQualifiedThing
+}
+```
+
+#### Member-injection methods
+
+Member injection methods are used to supply dependencies to the parameter supplied to the method.
+Method injection methods are defined as "Members-injection methods have a single parameter and
+inject dependencies into each of the Inject-annotated fields and methods of the passed instance. A
+members-injection method may be void or return its single parameter as a convenience for chaining"
+
+```kotlin
+// All valid member injection methods
+@Component
+interface AppComponent {
+    fun inject(target: MyFragment)
+    fun inject(target: MyOtherFragment): MyOtherFragment
+}
+```
+
+In the example above when you call `AppComponent.inject` in `MyFragment` any dependencies
+annotated with `@Inject` will be supplied.
+
+More information here: [
+`@Component` Dagger documentation](https://dagger.dev/api/latest/dagger/Component.html)
+
 ## Anvil Rules
 
 ### Prefer using `@ContributesBinding` over `@Binds`
@@ -383,7 +430,7 @@ class MyFragment : Fragment() {
     }
 }
 
-// Unsafe will throw UninitializedPropertyAccessException 
+// Unsafe will throw UninitializedPropertyAccessException
 // when trying to use `something`
 class MyOtherFragment : Fragment() {
 
@@ -459,7 +506,7 @@ interface MyUnsafeEntryPoint {
     fun getMyClass(): MyClass
 }
 
-// Safe 
+// Safe
 @InstallIn(SingletonComponent::class)
 @EntryPoint
 interface MySafeEntryPoint {

--- a/lint/annotation-constants/src/testFixtures/java/dev/whosnickdoglio/stubs/Hilt.kt
+++ b/lint/annotation-constants/src/testFixtures/java/dev/whosnickdoglio/stubs/Hilt.kt
@@ -2,7 +2,7 @@
  * Copyright (C) 2024 Nicholas Doglio
  * SPDX-License-Identifier: MIT
  */
-package dev.whosnickdoglio.hilt.detectors
+package dev.whosnickdoglio.stubs
 
 import com.android.tools.lint.checks.infrastructure.TestFiles
 

--- a/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/DaggerRulesIssueRegistry.kt
+++ b/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/DaggerRulesIssueRegistry.kt
@@ -16,6 +16,7 @@ import dev.whosnickdoglio.dagger.detectors.MissingModuleAnnotationDetector
 import dev.whosnickdoglio.dagger.detectors.MultipleScopesDetector
 import dev.whosnickdoglio.dagger.detectors.ScopedWithoutInjectAnnotationDetector
 import dev.whosnickdoglio.dagger.detectors.StaticProvidesDetector
+import dev.whosnickdoglio.dagger.detectors.ValidComponentMethodDetector
 
 @AutoService(IssueRegistry::class)
 public class DaggerRulesIssueRegistry : IssueRegistry() {
@@ -29,6 +30,7 @@ public class DaggerRulesIssueRegistry : IssueRegistry() {
             MultipleScopesDetector.ISSUE,
             StaticProvidesDetector.ISSUE,
             ScopedWithoutInjectAnnotationDetector.ISSUE,
+            ValidComponentMethodDetector.ISSUE,
         )
 
     override val api: Int = CURRENT_API

--- a/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ValidComponentMethodDetector.kt
+++ b/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ValidComponentMethodDetector.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 Nicholas Doglio
+ * SPDX-License-Identifier: MIT
+ */
+package dev.whosnickdoglio.dagger.detectors
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Incident
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiTypes
+import dev.whosnickdoglio.lint.annotations.anvil.CONTRIBUTES_SUBCOMPONENT
+import dev.whosnickdoglio.lint.annotations.anvil.MERGE_COMPONENT
+import dev.whosnickdoglio.lint.annotations.anvil.MERGE_SUBCOMPONENT
+import dev.whosnickdoglio.lint.annotations.dagger.COMPONENT
+import dev.whosnickdoglio.lint.annotations.dagger.SUBCOMPONENT
+import dev.whosnickdoglio.lint.annotations.hilt.ENTRY_POINT
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+
+/**
+ * A [Detector] that ensures all methods in a Dagger Component (or similar annotations for Anvil and
+ * Hilt) are valid and will not fail at compile time. Dagger components support two types of
+ * methods, provision methods and member injection methods, anything else will fail to compile.
+ *
+ * More info can be found in the
+ * [Dagger `@Component` documentation](https://dagger.dev/api/latest/dagger/Component.html)
+ */
+internal class ValidComponentMethodDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UAnnotation::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitAnnotation(node: UAnnotation) {
+                if (node.qualifiedName in components) {
+                    val component = node.uastParent as? UClass ?: return
+                    component.methods.forEach { method ->
+                        val isValidProvisionMethod = method.isValidProvisionMethod()
+                        val isValidMemberInjectionMethod = method.isValidMemberInjectionMethod()
+
+                        if (!isValidProvisionMethod && !isValidMemberInjectionMethod) {
+                            context.report(
+                                Incident()
+                                    .issue(ISSUE)
+                                    .location(context.getLocation(method))
+                                    .message(message(node.qualifiedName?.substringAfterLast(".")))
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+    private fun message(annotation: String?): String =
+        "Methods in a interface annotated with `@${annotation ?: "Component"}` either need to take a " +
+            "single parameter with no " +
+            "return type (member injection methods) or take no parameters and return a injected or " +
+            "provided type (provision methods), anything else will create a compile time error." +
+            "See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods " +
+            "for more information."
+
+    /**
+     * Returns `true` if the method is a valid provision method with no parameter with a non-void
+     * return type.
+     */
+    private fun UMethod.isValidProvisionMethod(): Boolean =
+        parameterList.isEmpty && returnType != PsiTypes.voidType()
+
+    /**
+     * Returns `true` if the method is a valid member injection method with a single parameter with
+     * a either a Unit/Void **or** the injected type return type.
+     */
+    private fun UMethod.isValidMemberInjectionMethod(): Boolean {
+        val numberOfParameters = parameterList.parametersCount
+        val parameter = parameterList.getParameter(0)
+        return numberOfParameters == 1 &&
+            // Return type can be Unit/Void **or** the injected type
+            (returnType == PsiTypes.voidType() || parameter?.type == returnType)
+    }
+
+    companion object {
+        internal val components =
+            setOf(
+                // Vanilla Dagger
+                COMPONENT,
+                SUBCOMPONENT,
+                // Anvil
+                MERGE_COMPONENT,
+                MERGE_SUBCOMPONENT,
+                CONTRIBUTES_SUBCOMPONENT,
+                // Hilt
+                ENTRY_POINT,
+            )
+
+        private val implementation =
+            Implementation(ValidComponentMethodDetector::class.java, Scope.JAVA_FILE_SCOPE)
+
+        internal val ISSUE =
+            Issue.create(
+                id = "ValidComponentMethod",
+                briefDescription = "Invalid `@Component` method",
+                explanation =
+                    "Methods in a `@Component` interface either need to take a single parameter with no " +
+                        "return type (member injection methods) or take no parameters and return a injected or " +
+                        "provided type (provision methods), anything else will create a compile time error." +
+                        "See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods " +
+                        "for more information.",
+                category = Category.CORRECTNESS,
+                priority = 5,
+                severity = Severity.ERROR,
+                implementation = implementation,
+            )
+    }
+}

--- a/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ValidComponentMethodDetectorTest.kt
+++ b/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ValidComponentMethodDetectorTest.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2024 Nicholas Doglio
+ * SPDX-License-Identifier: MIT
+ */
+package dev.whosnickdoglio.dagger.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import dev.whosnickdoglio.stubs.anvilAnnotations
+import dev.whosnickdoglio.stubs.daggerAnnotations
+import dev.whosnickdoglio.stubs.hiltAnnotations
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class ValidComponentMethodDetectorTest {
+
+    private class ValidComponentMethodDetectorTestParameterValueProvider :
+        TestParameterValuesProvider() {
+        override fun provideValues(context: Context?): List<*> =
+            ValidComponentMethodDetector.components.toList()
+    }
+
+    @TestParameter(valuesProvider = ValidComponentMethodDetectorTestParameterValueProvider::class)
+    lateinit var component: String
+
+    @Test
+    fun `kotlin component has valid provision method does not trigger error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.kotlin(
+                        """
+                package com.test.android
+
+                import $component
+
+                 @${component.substringAfterLast(".")}
+                 interface AppComponent {
+                     fun myThing(): String
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectWarningCount(0)
+    }
+
+    @Test
+    fun `java component has valid provision method does not trigger error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.java(
+                        """
+                package com.test.android;
+
+                import $component;
+
+                 @${component.substringAfterLast(".")}
+                 interface MyModule {
+                        String myString();
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectWarningCount(0)
+    }
+
+    @Test
+    fun `kotlin component with valid member injection method does not trigger error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.kotlin(
+                        """
+                package com.test.android
+
+                import $component
+
+                 @${component.substringAfterLast(".")}
+                 interface AppComponent {
+                     fun inject(target: String)
+                     fun inject(target: String): String
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectWarningCount(0)
+    }
+
+    @Test
+    fun `java component with valid member injection method does not trigger error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.java(
+                        """
+                package com.test.android;
+
+                import $component;
+
+                 @${component.substringAfterLast(".")}
+                 interface AppComponent {
+                     void inject(String target);
+                     String inject(String target);
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expectClean()
+            .expectWarningCount(0)
+    }
+
+    @Test
+    fun `kotlin component with invalid member injection methods triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.kotlin(
+                        """
+                package com.test.android
+
+                import $component
+
+                 @${component.substringAfterLast(".")}
+                 interface AppComponent {
+                     fun injectWithTwoParams(target: String, otherTarget: Int)
+                     fun injectWithReturnType(target: String): Int
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                    src/com/test/android/AppComponent.kt:7: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         fun injectWithTwoParams(target: String, otherTarget: Int)
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    src/com/test/android/AppComponent.kt:8: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         fun injectWithReturnType(target: String): Int
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    2 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectErrorCount(2)
+    }
+
+    @Test
+    fun `java component with invalid member injection methods triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.java(
+                        """
+                package com.test.android;
+
+                import $component;
+
+                 @${component.substringAfterLast(".")}
+                 interface AppComponent {
+                     void injectWithTwoParams(String target, Int otherTarget);
+                     String injectWithReturnType(Boolean target);
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                    src/com/test/android/AppComponent.java:7: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         void injectWithTwoParams(String target, Int otherTarget);
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    src/com/test/android/AppComponent.java:8: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         String injectWithReturnType(Boolean target);
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    2 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectErrorCount(2)
+    }
+
+    @Test
+    fun `kotlin component with invalid provision methods triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.kotlin(
+                        """
+                package com.test.android
+
+                import $component
+
+                 @${component.substringAfterLast(".")}
+                 interface AppComponent {
+                     fun myThingWithParameter(otherThing: String): Int
+                     fun myThingWithNoReturnType()
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                    src/com/test/android/AppComponent.kt:7: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         fun myThingWithParameter(otherThing: String): Int
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    src/com/test/android/AppComponent.kt:8: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         fun myThingWithNoReturnType()
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    2 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectErrorCount(2)
+    }
+
+    @Test
+    fun `java component with invalid provision methods triggers error`() {
+        TestLintTask.lint()
+            .files(
+                daggerAnnotations,
+                anvilAnnotations,
+                *hiltAnnotations,
+                TestFiles.java(
+                        """
+                package com.test.android;
+
+                import $component;
+
+                 @${component.substringAfterLast(".")}
+                 interface AppComponent {
+                     boolean myThingWithParameter(String otherThing);
+                     void myThingWithNoReturnType();
+                }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ValidComponentMethodDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                    src/com/test/android/AppComponent.java:7: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         boolean myThingWithParameter(String otherThing);
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    src/com/test/android/AppComponent.java:8: Error: Methods in a interface annotated with @${component.substringAfterLast(".")} either need to take a single parameter with no return type (member injection methods) or take no parameters and return a injected or provided type (provision methods), anything else will create a compile time error.See https://whosnickdoglio.dev/dagger-rules/rules/#valid-component-methods for more information. [ValidComponentMethod]
+                         void myThingWithNoReturnType();
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    2 errors, 0 warnings
+                """
+                    .trimIndent()
+            )
+            .expectErrorCount(2)
+    }
+}

--- a/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/EntryPointMustBeAnInterfaceDetectorTest.kt
+++ b/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/EntryPointMustBeAnInterfaceDetectorTest.kt
@@ -7,6 +7,7 @@ package dev.whosnickdoglio.hilt.detectors
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
 import dev.whosnickdoglio.lint.annotations.hilt.ENTRY_POINT
+import dev.whosnickdoglio.stubs.hiltAnnotations
 import org.junit.Test
 
 class EntryPointMustBeAnInterfaceDetectorTest {

--- a/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingAndroidEntryPointDetectorTest.kt
+++ b/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingAndroidEntryPointDetectorTest.kt
@@ -9,6 +9,7 @@ import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import dev.whosnickdoglio.lint.annotations.hilt.ANDROID_ENTRY_POINT
+import dev.whosnickdoglio.stubs.hiltAnnotations
 import dev.whosnickdoglio.stubs.javaxAnnotations
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingHiltAndroidAppAnnotationDetectorTest.kt
+++ b/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingHiltAndroidAppAnnotationDetectorTest.kt
@@ -7,6 +7,7 @@ package dev.whosnickdoglio.hilt.detectors
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
 import dev.whosnickdoglio.lint.annotations.hilt.HILT_ANDROID_APP
+import dev.whosnickdoglio.stubs.hiltAnnotations
 import org.junit.Test
 
 class MissingHiltAndroidAppAnnotationDetectorTest {

--- a/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingHiltViewModelAnnotationDetectorTest.kt
+++ b/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingHiltViewModelAnnotationDetectorTest.kt
@@ -7,6 +7,7 @@ package dev.whosnickdoglio.hilt.detectors
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
 import dev.whosnickdoglio.lint.annotations.hilt.HILT_VIEW_MODEL
+import dev.whosnickdoglio.stubs.hiltAnnotations
 import dev.whosnickdoglio.stubs.javaxAnnotations
 import org.junit.Test
 

--- a/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingInstallInDetectorTest.kt
+++ b/lint/hilt/src/test/java/dev/whosnickdoglio/hilt/detectors/MissingInstallInDetectorTest.kt
@@ -7,6 +7,7 @@ package dev.whosnickdoglio.hilt.detectors
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
 import dev.whosnickdoglio.stubs.daggerAnnotations
+import dev.whosnickdoglio.stubs.hiltAnnotations
 import org.junit.Test
 
 class MissingInstallInDetectorTest {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the style guidelines of this project (`./gradlew lint spotlessCheck`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have mentioned changes in [CHANGELOG.md](../CHANGELOG.md).
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.

<!-- branch-stack -->

- `main`
  - \#172 :point\_left:
