### PR TITLE
Enable ConstructorInjectionOverFieldInjectionDetector to be configured when using AppComponentFactory

### DIFF
--- a/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ConstructorInjectionOverFieldInjectionDetector.kt
+++ b/lint/dagger/src/main/java/dev/whosnickdoglio/dagger/detectors/ConstructorInjectionOverFieldInjectionDetector.kt
@@ -3,6 +3,7 @@
 package dev.whosnickdoglio.dagger.detectors
 
 import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.BooleanOption
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Implementation
@@ -28,23 +29,21 @@ internal class ConstructorInjectionOverFieldInjectionDetector : Detector(), Sour
     override fun getApplicableUastTypes(): List<Class<out UElement>> =
         listOf(UAnnotation::class.java)
 
-    override fun createUastHandler(context: JavaContext): UElementHandler {
-        return object : UElementHandler() {
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
             override fun visitAnnotation(node: UAnnotation) {
                 if (node.qualifiedName == INJECT) {
                     val annotatedElement = node.uastParent as? UField ?: return
-                    //                        val fullAllowList: List<String> =
-                    //                            if (context.mainProject.minSdk >= MIN_SDK) {
-                    //
-                    // allowList.defaultValue?.split(",").orEmpty()
-                    //                            } else {
-                    //
-                    // allowList.defaultValue?.split(",").orEmpty() + androidComponents
-                    //                            }
+                    val fullAllowList: List<String> =
+                        if (usingAppComponentFactory.getValue(context)) {
+                            allowList.getValue(context)?.split(",").orEmpty()
+                        } else {
+                            allowList.getValue(context)?.split(",").orEmpty() + androidComponents
+                        }
 
                     val containingClass =
                         (annotatedElement.javaPsi as? PsiField)?.containingClass ?: return
-                    val isAllowedFieldInjection = androidComponents.any { className ->
+                    val isAllowedFieldInjection = fullAllowList.any { className ->
                         context.evaluator.extendsClass(
                             cls = containingClass,
                             className = className,
@@ -52,7 +51,6 @@ internal class ConstructorInjectionOverFieldInjectionDetector : Detector(), Sour
                         )
                     }
 
-                    //                        minSdkLessThan(28)
                     if (!isAllowedFieldInjection) {
                         context.report(
                             Incident(
@@ -66,13 +64,8 @@ internal class ConstructorInjectionOverFieldInjectionDetector : Detector(), Sour
                 }
             }
         }
-    }
 
     companion object {
-        //        private const val MIN_SDK = 28
-
-        // TODO make this configurable
-        @Suppress("UnusedPrivateProperty")
         private val allowList =
             StringOption(
                 name = "allowList",
@@ -81,8 +74,10 @@ internal class ConstructorInjectionOverFieldInjectionDetector : Detector(), Sour
                 explanation = "",
             )
 
-        //
-        private val androidComponents =
+        internal val usingAppComponentFactory =
+            BooleanOption(name = "usingAppComponentFactory", description = "TOOD", explanation = "")
+
+        internal val androidComponents =
             setOf(
                 // https://developer.android.com/reference/android/app/AppComponentFactory
                 "android.app.Activity",
@@ -103,18 +98,19 @@ internal class ConstructorInjectionOverFieldInjectionDetector : Detector(), Sour
 
         internal val ISSUE =
             Issue.create(
-                id = "ConstructorOverField",
-                briefDescription = "Class is using field injection over constructor injection",
-                explanation =
-                    """
+                    id = "ConstructorOverField",
+                    briefDescription = "Class is using field injection over constructor injection",
+                    explanation =
+                        """
                     Constructor injection should be favored over field injection for classes that support it.
 
                     See https://whosnickdoglio.dev/dagger-rules/rules/#prefer-constructor-injection-over-field-injection for more information.
                 """,
-                category = Category.CORRECTNESS,
-                priority = 5,
-                severity = Severity.WARNING,
-                implementation = implementation,
-            )
+                    category = Category.CORRECTNESS,
+                    priority = 5,
+                    severity = Severity.WARNING,
+                    implementation = implementation,
+                )
+                .setOptions(listOf(usingAppComponentFactory, allowList))
     }
 }

--- a/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ConstructorInjectionOverFieldInjectionDetectorTest.kt
+++ b/lint/dagger/src/test/java/dev/whosnickdoglio/dagger/detectors/ConstructorInjectionOverFieldInjectionDetectorTest.kt
@@ -184,6 +184,130 @@ class ConstructorInjectionOverFieldInjectionDetectorTest {
             .expectWarningCount(1)
     }
 
+    @Test
+    fun `android subclass in kotlin does triggers member injection warning when usingAppComponentFactory is enabled`() {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                TestFiles.kotlin(
+                        """
+                package ${component.classPackage}
+
+                class ${component.className}
+
+                """
+                    )
+                    .indented(),
+                TestFiles.kotlin(
+                        """
+                package androidx
+
+                import ${component.classImport}
+
+                class AndroidX${component.className}: ${component.className}
+                    """
+                    )
+                    .indented(),
+                TestFiles.kotlin(
+                        """
+            package com.test.android
+
+            import javax.inject.Inject
+            import androidx.AndroidX${component.className}
+
+            class Something
+
+            class My${component.className}: AndroidX${component.className} {
+
+            @Inject lateinit var something: Something
+
+            }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ConstructorInjectionOverFieldInjectionDetector.ISSUE)
+            .configureOption(
+                ConstructorInjectionOverFieldInjectionDetector.usingAppComponentFactory,
+                true,
+            )
+            .run()
+            .expect(
+                """
+                src/com/test/android/Something.kt:10: Warning: Constructor injection should be favored over field injection for classes that support it.
+
+                See https://whosnickdoglio.dev/dagger-rules/rules/#prefer-constructor-injection-over-field-injection for more information. [ConstructorOverField]
+                @Inject lateinit var something: Something
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                0 errors, 1 warnings
+                """
+                    .trimIndent()
+            )
+            .expectWarningCount(1)
+    }
+
+    @Test
+    fun `android subclass in java does triggers member injection warning when usingAppComponentFactory is enabled`() {
+        TestLintTask.lint()
+            .files(
+                javaxAnnotations,
+                TestFiles.java(
+                        """
+                package ${component.classPackage};
+
+                class ${component.className} {}
+
+                """
+                    )
+                    .indented(),
+                TestFiles.java(
+                        """
+                package androidx;
+
+                import ${component.classImport};
+
+                class AndroidX${component.className} extends ${component.className} {}
+                    """
+                    )
+                    .indented(),
+                TestFiles.java(
+                        """
+            package com.test.android;
+
+            import javax.inject.Inject;
+            import androidx.AndroidX${component.className};
+
+            class Something {}
+
+            class My${component.className} extends AndroidX${component.className} {
+
+            @Inject Something something;
+
+            }
+                """
+                    )
+                    .indented(),
+            )
+            .issues(ConstructorInjectionOverFieldInjectionDetector.ISSUE)
+            .configureOption(
+                ConstructorInjectionOverFieldInjectionDetector.usingAppComponentFactory,
+                true,
+            )
+            .run()
+            .expect(
+                """
+                src/com/test/android/Something.java:10: Warning: Constructor injection should be favored over field injection for classes that support it.
+
+                See https://whosnickdoglio.dev/dagger-rules/rules/#prefer-constructor-injection-over-field-injection for more information. [ConstructorOverField]
+                @Inject Something something;
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                0 errors, 1 warnings
+                """
+                    .trimIndent()
+            )
+            .expectWarningCount(1)
+    }
+
     @Suppress("unused")
     enum class AndroidComponentParameters(
         val className: String,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the style guidelines of this project (`./gradlew lint spotlessCheck`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
- [ ] I have mentioned changes in [CHANGELOG.md](../CHANGELOG.md).
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.

* `main` <!-- branch-stack -->
  - **Enable ConstructorInjectionOverFieldInjectionDetector to be configured when using AppComponentFactory** :point\_left:
