### PR TITLE
Modify the PR template to avoid the PR stack workflow from removing parts of the template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,6 @@
 
 <!--- Describe your changes in detail -->
 
-## PR Stack
-
-<!-- branch-stack -->
-
 ## Related Issue
 
 <!--- This project only accepts pull requests related to open issues -->
@@ -22,3 +18,8 @@
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have mentioned changes in [CHANGELOG.md](../CHANGELOG.md).
 - [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
+
+
+## PR Stack
+
+<!-- branch-stack -->


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have mentioned changes in [CHANGELOG.md](../CHANGELOG.md).
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.

## PR Stack

<!-- branch-stack -->

- `main`
  - \#258 :point\_left:
